### PR TITLE
Record name subject raw keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ dl-*
 *.whl
 .pytest_cache
 staging
+env

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ key = {"name": "Key"}
 avroProducer = AvroProducer({
     'bootstrap.servers': 'mybroker,mybroker2',
     'schema.registry.url': 'http://schem_registry_host:port'
-    }, default_key_schema=key_schema, default_value_schema=value_schema)
+    }, default_value_schema=value_schema)
 
 avroProducer.produce(topic='my_topic', value=value, key=key)
 avroProducer.flush()

--- a/confluent_kafka/avro/__init__.py
+++ b/confluent_kafka/avro/__init__.py
@@ -55,7 +55,6 @@ class AvroProducer(Producer):
             :param object value: An object to serialize
             :param str value_schema: Avro schema for value
             :param object key: An object to serialize
-            :param str key_schema: Avro schema for key
 
             Plus any other parameters accepted by confluent_kafka.Producer.produce
 

--- a/confluent_kafka/avro/serializer/message_serializer.py
+++ b/confluent_kafka/avro/serializer/message_serializer.py
@@ -79,13 +79,12 @@ class MessageSerializer(object):
 
     '''
 
-    def encode_record_with_schema(self, topic, schema, record, is_key=False):
+    def encode_record_with_schema(self, schema, record, is_key=False):
         """
-        Given a parsed avro schema, encode a record for the given topic.  The
+        Given a parsed avro schema, encode a record.  The
         record is expected to be a dictionary.
 
-        The schema is registered with the subject of 'topic-value'
-        @:param topic : Topic name
+        The schema is registered with the subject of 'namespace.name'
         @:param schema : Avro Schema
         @:param record : An object to serialize
         @:param is_key : If the record is a key
@@ -93,9 +92,8 @@ class MessageSerializer(object):
         """
         serialize_err = KeySerializerError if is_key else ValueSerializerError
 
-        subject_suffix = ('-key' if is_key else '-value')
-        # get the latest schema for the subject
-        subject = topic + subject_suffix
+        subject = schema.namespace + '.' + schema.name
+
         # register it
         schema_id = self.registry_client.register(subject, schema)
         if not schema_id:

--- a/tests/avro/test_avro_producer.py
+++ b/tests/avro/test_avro_producer.py
@@ -70,7 +70,7 @@ class TestAvroProducer(unittest.TestCase):
     def test_produce_value_and_key_schemas(self):
         value_schema = avro.load(os.path.join(avsc_dir, "basic_schema.avsc"))
         producer = AvroProducer({'schema.registry.url': 'http://127.0.0.1:9001'}, default_value_schema=value_schema,
-                                default_key_schema=value_schema)
+                                )
         with self.assertRaises(ConnectionError):  # Unexistent schema-registry
             producer.produce(topic='test', value={"name": 'abc"'}, key={"name": 'abc"'})
 
@@ -121,6 +121,5 @@ class TestAvroProducer(unittest.TestCase):
         value_schema = avro.load(os.path.join(avsc_dir, "primitive_float.avsc"))
         schema_registry = MockSchemaRegistryClient()
         producer = AvroProducer({}, schema_registry=schema_registry,
-                                default_key_schema=key_schema,
                                 default_value_schema=value_schema)
         producer.produce(topic='test', value=0.0, key='')

--- a/tests/avro/test_avro_producer.py
+++ b/tests/avro/test_avro_producer.py
@@ -50,8 +50,7 @@ class TestAvroProducer(unittest.TestCase):
             producer.produce(topic='test', value={"name": 'abc"'})
 
     def test_produce_no_value(self):
-        key_schema = avro.load(os.path.join(avsc_dir, "basic_schema.avsc"))
-        producer = AvroProducer({'schema.registry.url': 'http://127.0.0.1:9001'}, default_key_schema=key_schema)
+        producer = AvroProducer({'schema.registry.url': 'http://127.0.0.1:9001'})
         with self.assertRaises(ConnectionError):  # Unexistent schema-registry
             producer.produce(topic='test', key={"name": 'abc"'})
 
@@ -76,26 +75,21 @@ class TestAvroProducer(unittest.TestCase):
 
     def test_produce_primitive_string_key(self):
         value_schema = avro.load(os.path.join(avsc_dir, "basic_schema.avsc"))
-        key_schema = avro.load(os.path.join(avsc_dir, "primitive_string.avsc"))
         producer = AvroProducer({'schema.registry.url': 'http://127.0.0.1:9001'})
         with self.assertRaises(ConnectionError):  # Unexistent schema-registry
-            producer.produce(topic='test', value={"name": 'abc"'}, value_schema=value_schema, key='mykey',
-                             key_schema=key_schema)
+            producer.produce(topic='test', value={"name": 'abc"'}, value_schema=value_schema, key='mykey')
 
     def test_produce_primitive_key_and_value(self):
         value_schema = avro.load(os.path.join(avsc_dir, "primitive_float.avsc"))
-        key_schema = avro.load(os.path.join(avsc_dir, "primitive_string.avsc"))
         producer = AvroProducer({'schema.registry.url': 'http://127.0.0.1:9001'})
         with self.assertRaises(ConnectionError):  # Unexistent schema-registry
-            producer.produce(topic='test', value=32., value_schema=value_schema, key='mykey', key_schema=key_schema)
+            producer.produce(topic='test', value=32., value_schema=value_schema, key='mykey')
 
     def test_produce_with_custom_registry(self):
         schema_registry = MockSchemaRegistryClient()
         value_schema = avro.load(os.path.join(avsc_dir, "basic_schema.avsc"))
-        key_schema = avro.load(os.path.join(avsc_dir, "primitive_string.avsc"))
         producer = AvroProducer({}, schema_registry=schema_registry)
-        producer.produce(topic='test', value={"name": 'abc"'}, value_schema=value_schema, key='mykey',
-                         key_schema=key_schema)
+        producer.produce(topic='test', value={"name": 'abc"'}, value_schema=value_schema, key='mykey')
 
     def test_produce_with_custom_registry_and_registry_url(self):
         schema_registry = MockSchemaRegistryClient()
@@ -117,7 +111,6 @@ class TestAvroProducer(unittest.TestCase):
             producer.produce(topic='test', value=0.0, key='')
 
     def test_produce_with_empty_key_value_with_schema(self):
-        key_schema = avro.load(os.path.join(avsc_dir, "primitive_string.avsc"))
         value_schema = avro.load(os.path.join(avsc_dir, "primitive_float.avsc"))
         schema_registry = MockSchemaRegistryClient()
         producer = AvroProducer({}, schema_registry=schema_registry,

--- a/tests/avro/test_message_serializer.py
+++ b/tests/avro/test_message_serializer.py
@@ -72,7 +72,7 @@ class TestMessageSerializer(unittest.TestCase):
         schema_id = self.client.register(subject, basic)
         records = data_gen.BASIC_ITEMS
         for record in records:
-            message = self.ms.encode_record_with_schema(topic, basic, record)
+            message = self.ms.encode_record_with_schema(basic, record)
             self.assertMessageIsSame(message, record, schema_id)
 
     def test_decode_none(self):

--- a/tests/avro/test_message_serializer.py
+++ b/tests/avro/test_message_serializer.py
@@ -66,7 +66,6 @@ class TestMessageSerializer(unittest.TestCase):
             self.assertMessageIsSame(message, record, adv_schema_id)
 
     def test_encode_record_with_schema(self):
-        topic = 'test'
         basic = avro.loads(data_gen.BASIC_SCHEMA)
         subject = 'test-value'
         schema_id = self.client.register(subject, basic)


### PR DESCRIPTION
Two high-level changes, to match what we're doing from Scala now:
* we want to be able to send Kafka messages with string keys, not mediated by Avro at all
* we want schema subjects to be derived from the names of records, not topic name/schema role

(For background: the non-python Kafka libs allow configurable key serialization and schema subject selection, which is why we haven't run into this outside Admiral. The python lib is just a bit more narrow.)

I took the approach of just hardcoding _our_ assumptions, in place of the originals. This has some corollaries:

* primitive values cannot be sent. If it's not a record, we can't get a subject name, so we can't serialize it
* all keys are just strings. If you send a non-string key, no dice; we don't serialize it.

I can certainly see a version of this fork that basically ports over the various JVM lib features that allow us to have it all, but that seemed like a deep well to go down.

The tests pass. I'm puzzling over whether to go through the setup to run the full integration tests, but they're reasonably involved. Thought I'd open this now to get eyes on it!